### PR TITLE
Last Pot Screen

### DIFF
--- a/app/src/main/java/com/example/pigkeeper/LastPotActivity.kt
+++ b/app/src/main/java/com/example/pigkeeper/LastPotActivity.kt
@@ -1,11 +1,37 @@
 package com.example.pigkeeper
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
 
 class LastPotActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_last_pot)
+
+        val playerNames = arrayOf("Player 1", "Player 2", "Player 3", "Player 4", "Player 5", "Player 6"
+                                    , "Player 7", "Player 8", "Player 9", "Player 10")
+        val playerScores = intArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+        val lastPotScores = mutableMapOf<String, Int>()
+        for (i in playerNames.indices) {
+            lastPotScores[playerNames[i]] = playerScores[i]
+        }
+
+        val textViewLastPotScores = findViewById<TextView>(R.id.textViewLastPotScores)
+
+        val formattedScores = StringBuilder()
+        for ((player, score) in lastPotScores) {
+            formattedScores.append("$player: $score\n")
+        }
+
+        textViewLastPotScores.text = formattedScores.toString()
+
+
+
+        val buttonBack = findViewById<Button>(R.id.buttonBack)
+        buttonBack.setOnClickListener{startActivity(Intent(this@LastPotActivity, MainActivity::class.java))}
     }
 }

--- a/app/src/main/res/drawable/border_black.xml
+++ b/app/src/main/res/drawable/border_black.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="2dp"
+        android:color="#000000" />
+</shape>

--- a/app/src/main/res/layout/activity_last_pot.xml
+++ b/app/src/main/res/layout/activity_last_pot.xml
@@ -15,8 +15,34 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Display2"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.5" />
+        app:layout_constraintVertical_bias="0.209" />
+
+    <Button
+        android:id="@+id/buttonBack"
+        android:layout_width="159dp"
+        android:layout_height="66dp"
+        android:text="Back"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.487"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.868" />
+
+    <TextView
+        android:id="@+id/textViewLastPotScores"
+        android:layout_width="312dp"
+        android:layout_height="405dp"
+        android:background="@drawable/border_black"
+        android:text="TextView"
+        android:gravity="center"
+        android:textSize="25sp"
+        app:layout_constraintBottom_toTopOf="@+id/buttonBack"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textLastPot" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Completed Last Pot Screen

Important Notes:
- playerNames and playerScores are currently stored as a key-value map. At the moment, I hardcoded playerNames and playerScores just so that we can see the layout. 
- buttonBack leads the user back to the main screen
- In res/drawables, I have added the file "border_black.xml" This is so that it creates the black border around the leaderboard. We don't have to keep this.
